### PR TITLE
Enable documenter-dark theme, add minimum compat entries for docs dependencies

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,8 @@
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FASTX = "c2308a5c-f048-11e8-3e8a-31650f418d12"
+
+[compat]
+BioSequences = "3"
+Documenter = "0.27"
+FASTX = "2"


### PR DESCRIPTION
# Enable `documenter-dark` theme, add minimum compat entries for docs dependencies

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [X] :sparkles: New feature (A non-breaking change which adds functionality).

## :clipboard: Additional detail

- Enable `documenter-dark` theme (bump Documenter to v0.27)
- Add minimum compat entries for all dependencies required to generate the docs 

## :ballot_box_with_check: Checklist

- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
